### PR TITLE
check if RefundFor exists

### DIFF
--- a/Crossroads.Service.Finance/Services/Pushpay/PushpayService.cs
+++ b/Crossroads.Service.Finance/Services/Pushpay/PushpayService.cs
@@ -122,14 +122,14 @@ namespace Crossroads.Service.Finance.Services
                     donation.DonationStatusDate = DateTime.Now;
                 }
 
-                // Set payment type for refunds
-                var refund = _donationService.GetDonationByTransactionCode(pushpayPayment.RefundFor.TransactionId);
-                if (refund != null)
+                // check if refund
+                if (pushpayPayment.RefundFor != null)
                 {
-                    Console.WriteLine("Refunded Transaction Id: " + refund.TransactionCode);
+                    // Set payment type for refunds
+                    var refund = _donationService.GetDonationByTransactionCode(pushpayPayment.RefundFor.TransactionId);
+                    Console.WriteLine("Refunding Transaction Id: " + refund.TransactionCode);
                     donation.PaymentTypeId = refund.PaymentTypeId;
                 }
-
                 _donationService.Update(donation);
                 return donation;
             } catch (Exception e) {

--- a/Crossroads.Service.Finance/Services/Pushpay/PushpayService.cs
+++ b/Crossroads.Service.Finance/Services/Pushpay/PushpayService.cs
@@ -141,7 +141,7 @@ namespace Crossroads.Service.Finance.Services
                 {
                     AddUpdateDonationStatusFromPushpayJob(webhook);
                     // dont throw an exception as Hangfire tries to handle it
-                    _logger.Error($"Payment: {webhook.Events[0].Links.Payment} not found in MP. Trying again in a minute.", e);
+                    Console.WriteLine($"Payment: {webhook.Events[0].Links.Payment} not found in MP. Trying again in a minute.", e);
                     return null;
                 }
                 // it's been more than 10 minutes, let's chalk it up as PushPay
@@ -149,7 +149,7 @@ namespace Crossroads.Service.Finance.Services
                 else
                 {
                     // dont throw an exception as Hangfire tries to handle it
-                    _logger.Error($"Payment: {webhook.Events[0].Links.Payment} not found in MP after 10 minutes of trying. Giving up.", e);
+                    Console.WriteLine($"Payment: {webhook.Events[0].Links.Payment} not found in MP after 10 minutes of trying. Giving up.", e);
                     return null;
                 }
             }


### PR DESCRIPTION
this is a hotfix found during staff training where payment status changed/created webhook was not updating anything as it was blowing up on RefundFor