### PR TITLE
Update to 2 replicas of service in kubernetes

### DIFF
--- a/deployment/kubernetes/deployment.yml
+++ b/deployment/kubernetes/deployment.yml
@@ -4,11 +4,11 @@ metadata:
   name: crds-finance
   namespace: api
 spec: 
-  replicas: 1 
+  replicas: 2
   strategy: 
     type: RollingUpdate 
     rollingUpdate: 
-      maxSurge: 1 
+      maxSurge: 2
       maxUnavailable: 0 
   template: 
     metadata: 


### PR DESCRIPTION
Service will have 2 instances running at all times and can scale up to 4 instances during updates to ensure zero downtime.