### PR TITLE
defect/DE6899-pusphpay-site-key-as-env-var

### DIFF
--- a/Crossroads.Service.Finance/Services/Pushpay/PushpayService.cs
+++ b/Crossroads.Service.Finance/Services/Pushpay/PushpayService.cs
@@ -41,7 +41,7 @@ namespace Crossroads.Service.Finance.Services
         private const int maxRetryMinutes = 15;
         private const int pushpayProcessorTypeId = 1;
         private const int NotSiteSpecificCongregationId = 5;
-        private const string CongregationFieldKey = "100200437826";
+        private readonly string CongregationFieldKey = Environment.GetEnvironmentVariable("PUSHPAY_SITE_FIELD_KEY");
 
         public PushpayService(IPushpayClient pushpayClient, IDonationService donationService, IMapper mapper,
                               IConfigurationWrapper configurationWrapper, IRecurringGiftRepository recurringGiftRepository,

--- a/deployment/kubernetes/deployment.yml
+++ b/deployment/kubernetes/deployment.yml
@@ -76,6 +76,8 @@ spec:
               value: $PUSHPAY_CLIENT_SECRET
             - name: PUSHPAY_MERCHANT_KEY            
               value: $PUSHPAY_MERCHANT_KEY
+            - name: PUSHPAY_SITE_FIELD_KEY
+              value: $PUSHPAY_SITE_FIELD_KEY
             - name: NEW_RELIC_LICENSE_KEY            
               value: $NR_INSTALL_KEY
             - name: NEW_RELIC_APP_NAME


### PR DESCRIPTION
Pushpay has indicated that their UI field ID will be variable in the future, so we want to be able to get a value / environment, rather than sharing a single key across all 3 envs.