### PR TITLE
Feature/us18318 mass edit donations

### DIFF
--- a/Crossroads.Service.Finance.Test/Exports/ExportServiceTest.cs
+++ b/Crossroads.Service.Finance.Test/Exports/ExportServiceTest.cs
@@ -13,12 +13,14 @@ using MinistryPlatform.Models;
 using Mock;
 using Xunit;
 using Crossroads.Service.Finance.Services.JournalEntryBatch;
+using Crossroads.Service.Finance.Services.JournalEntry;
 
 namespace Crossroads.Service.Finance.Test.Exports
 {
     public class ExportServiceTest
     {
         private readonly Mock<IAdjustmentRepository> _adjustmentRepository;
+        private readonly Mock<IJournalEntryService> _journalEntryService;
         private readonly Mock<IJournalEntryBatchService> _batchService;
         private readonly Mock<IJournalEntryRepository> _journalEntryRepository;
         private readonly Mock<IJournalEntryExport> _journalEntryExport;
@@ -29,12 +31,14 @@ namespace Crossroads.Service.Finance.Test.Exports
         public ExportServiceTest()
         {
             _adjustmentRepository = new Mock<IAdjustmentRepository>();
+            _journalEntryService = new Mock<IJournalEntryService>();
             _batchService = new Mock<IJournalEntryBatchService>();
             _journalEntryRepository = new Mock<IJournalEntryRepository>();
             _journalEntryExport = new Mock<IJournalEntryExport>();
             _mapper = new Mock<IMapper>();
 
             _fixture = new ExportService(_adjustmentRepository.Object,
+                                        _journalEntryService.Object,
                                         _batchService.Object,
                                         _journalEntryRepository.Object, 
                                         _journalEntryExport.Object,

--- a/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
+++ b/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using AutoMapper;
-using Crossroads.Service.Finance.Models;
-using Crossroads.Service.Finance.Interfaces;
-using Crossroads.Service.Finance.Services;
-using Crossroads.Web.Common.Configuration;
-using MinistryPlatform.Interfaces;
+﻿using Crossroads.Service.Finance.Services.JournalEntry;
 using MinistryPlatform.Models;
-using Mock;
-using Xunit;
-using Moq;
-using Utilities.Logging;
-using Crossroads.Service.Finance.Services.JournalEntry;
+using System;
 using System.Collections.Generic;
+using Xunit;
 
 namespace Crossroads.Service.Finance.Test.JournalEntry
 {

--- a/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
+++ b/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
@@ -40,7 +40,7 @@ namespace Crossroads.Service.Finance.Test.JournalEntry
         }
 
         [Fact]
-        public void ShouldNotAdjustZeroViaNetMethodAmounts()
+        public void ShouldNotAttemptToNetBalancedDebitsAndCredits()
         {
             var sampleJournalEntry = CreateTestJournalEntry(0, 0);
 

--- a/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
+++ b/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using AutoMapper;
+using Crossroads.Service.Finance.Models;
+using Crossroads.Service.Finance.Interfaces;
+using Crossroads.Service.Finance.Services;
+using Crossroads.Web.Common.Configuration;
+using MinistryPlatform.Interfaces;
+using MinistryPlatform.Models;
+using Mock;
+using Xunit;
+using Moq;
+using Utilities.Logging;
+using Crossroads.Service.Finance.Services.JournalEntry;
+using System.Collections.Generic;
+
+namespace Crossroads.Service.Finance.Test.JournalEntry
+{
+    public class JournalEntriesTest
+    {
+        private readonly IJournalEntryService _fixture;
+
+        public JournalEntriesTest()
+        {
+            _fixture = new JournalEntryService();
+        }
+
+        [Fact]
+        public void ShouldAddCreditAmountToAnExistingJournalEntry()
+        {
+            var sampleJournalEntry = CreateTestJournalEntry(20, 5000);
+            var sampleAdjustment = CreateTestDistributionAdjustment(500);
+
+            MpJournalEntry actualAdjusted =_fixture.AdjustExistingJournalEntry(sampleAdjustment, sampleJournalEntry);
+            MpJournalEntry expectedAdjusted = CreateTestJournalEntry(20, 5500);
+
+            Assert.Equal(expectedAdjusted.CreditAmount, actualAdjusted.CreditAmount);
+            Assert.Equal(expectedAdjusted.DebitAmount, actualAdjusted.DebitAmount);
+        }
+
+        [Fact]
+        public void ShouldNetCreditsAndDebitsWhenCreditAmountHigher() {
+            var sampleJournalEntry = CreateTestJournalEntry(20, 5000);
+
+            MpJournalEntry actualAdjusted = _fixture.NetCreditsAndDebits(sampleJournalEntry);
+            MpJournalEntry expectedAdjusted = CreateTestJournalEntry(0, 4980);
+
+            Assert.Equal(expectedAdjusted.CreditAmount, actualAdjusted.CreditAmount);
+            Assert.Equal(expectedAdjusted.DebitAmount, actualAdjusted.DebitAmount);
+        }
+
+        [Fact]
+        public void ShouldNotAdjustZeroViaNetMethodAmounts()
+        {
+            var sampleJournalEntry = CreateTestJournalEntry(0, 0);
+
+            MpJournalEntry actualAdjusted = _fixture.NetCreditsAndDebits(sampleJournalEntry);
+            MpJournalEntry expectedAdjusted = CreateTestJournalEntry(0, 0);
+
+            Assert.Equal(expectedAdjusted.CreditAmount, actualAdjusted.CreditAmount);
+            Assert.Equal(expectedAdjusted.DebitAmount, actualAdjusted.DebitAmount);
+        }
+
+        [Fact]
+        public void ShouldStripOutAnyWashJournalEntries()
+        {
+            var sampleJournalEntry1 = CreateTestJournalEntry(0, 0);
+            var sampleJournalEntry2 = CreateTestJournalEntry(1, 0);
+            var sampleJournalEntry3 = CreateTestJournalEntry(0, 2);
+            var sampleJournalEntry4 = CreateTestJournalEntry(5, 2);
+            var sampleJournalEntry5 = CreateTestJournalEntry(5, 5);
+
+            List<MpJournalEntry> journalEntries = new List<MpJournalEntry> { sampleJournalEntry1, sampleJournalEntry2,
+                                                                             sampleJournalEntry3, sampleJournalEntry4,
+                                                                             sampleJournalEntry4 };
+
+            var adjusted = _fixture.RemoveWashEntries(journalEntries);
+
+            var expectedCountWithoutWashEntries = 4;
+
+            Assert.Equal(expectedCountWithoutWashEntries, adjusted.Count);
+        }
+
+
+
+        private MpJournalEntry CreateTestJournalEntry(decimal debit, decimal credit) {
+            var mpJournalEntry = new MpJournalEntry
+            {
+                BatchID = "123",
+                CreatedDate = DateTime.Now,
+                ExportedDate = null,
+                Description = "test desc",
+                GL_Account_Number = "123",
+                AdjustmentYear = new DateTime(2019, 08, 01).Year,
+                AdjustmentMonth = new DateTime(2019, 08, 01).Month,
+                CreditAmount = credit,
+                DebitAmount = debit
+            };
+
+            return mpJournalEntry;
+        }
+
+        private MpDistributionAdjustment CreateTestDistributionAdjustment(int amount) {
+            return new MpDistributionAdjustment
+            {
+                GLAccountNumber = "40001-325-02",
+                DonationDate = new DateTime(2019, 08, 01),
+                Amount = amount
+            };
+        }
+        
+    }
+}

--- a/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
+++ b/Crossroads.Service.Finance.Test/JournalEntry/JournalEntryServiceTest.cs
@@ -21,11 +21,11 @@ namespace Crossroads.Service.Finance.Test.JournalEntry
             var sampleJournalEntry = CreateTestJournalEntry(20, 5000);
             var sampleAdjustment = CreateTestDistributionAdjustment(500);
 
-            MpJournalEntry actualAdjusted =_fixture.AdjustExistingJournalEntry(sampleAdjustment, sampleJournalEntry);
+            _fixture.AdjustExistingJournalEntry(sampleAdjustment, sampleJournalEntry);
             MpJournalEntry expectedAdjusted = CreateTestJournalEntry(20, 5500);
 
-            Assert.Equal(expectedAdjusted.CreditAmount, actualAdjusted.CreditAmount);
-            Assert.Equal(expectedAdjusted.DebitAmount, actualAdjusted.DebitAmount);
+            Assert.Equal(expectedAdjusted.CreditAmount, sampleJournalEntry.CreditAmount);
+            Assert.Equal(expectedAdjusted.DebitAmount, sampleJournalEntry.DebitAmount);
         }
 
         [Fact]
@@ -70,8 +70,6 @@ namespace Crossroads.Service.Finance.Test.JournalEntry
 
             Assert.Equal(expectedCountWithoutWashEntries, adjusted.Count);
         }
-
-
 
         private MpJournalEntry CreateTestJournalEntry(decimal debit, decimal credit) {
             var mpJournalEntry = new MpJournalEntry

--- a/Crossroads.Service.Finance/Controllers/ExportController.cs
+++ b/Crossroads.Service.Finance/Controllers/ExportController.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Linq;
-using Crossroads.Service.Finance.Services.Exports;
+﻿using Crossroads.Service.Finance.Services.Exports;
 using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace Crossroads.Service.Finance.Controllers
 {

--- a/Crossroads.Service.Finance/Services/Exports/ExportService.cs
+++ b/Crossroads.Service.Finance/Services/Exports/ExportService.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Crossroads.Service.Finance.Services.JournalEntry;
 using Crossroads.Service.Finance.Services.JournalEntryBatch;
 using Exports.JournalEntries;
 using Exports.Models;
@@ -15,12 +16,14 @@ namespace Crossroads.Service.Finance.Services.Exports
     public class ExportService: IExportService
     {
         private readonly IAdjustmentRepository _adjustmentRepository;
+        private readonly IJournalEntryService _journalEntryService;
         private readonly IJournalEntryBatchService _batchService;
         private readonly IJournalEntryRepository _journalEntryRepository;
         private readonly IJournalEntryExport _journalEntryExport;
         private readonly IMapper _mapper;
 
         public ExportService(IAdjustmentRepository adjustmentRepository,
+                             IJournalEntryService journalEntryService,
                              IJournalEntryBatchService batchService,
                              IJournalEntryRepository journalEntryRepository, 
                              IJournalEntryExport journalEntryExport,
@@ -28,6 +31,7 @@ namespace Crossroads.Service.Finance.Services.Exports
         {
             _adjustmentRepository = adjustmentRepository;
             _batchService = batchService;
+            _journalEntryService = journalEntryService;
             _journalEntryRepository = journalEntryRepository;
             _journalEntryExport = journalEntryExport;
             _mapper = mapper;
@@ -43,53 +47,8 @@ namespace Crossroads.Service.Finance.Services.Exports
             // TODO: We need to verify this batch ID with Finance and Velosio
             var batchId = $"CRJE{today.Year}{today.Month}{today.Day}01";
 
-            var journalEntries = new List<MpJournalEntry>();
-
-            foreach (var mpDistributionAdjustment in mpDistributionAdjustments)
-            {
-                var matchingMpJournalEntry = journalEntries.FirstOrDefault(r => r.GL_Account_Number == mpDistributionAdjustment.GLAccountNumber &&
-                                            r.AdjustmentYear == mpDistributionAdjustment.DonationDate.Year &&
-                                            r.AdjustmentMonth == mpDistributionAdjustment.DonationDate.Month);
-
-                // TODO: verify if this will ever be null
-                if (matchingMpJournalEntry == null)
-                {
-                    var mpJournalEntry = new MpJournalEntry
-                    {
-                        BatchID = batchId,
-                        CreatedDate = DateTime.Now,
-                        ExportedDate = null,
-                        Description = "test desc", // TODO: understand what goes here
-                        GL_Account_Number = mpDistributionAdjustment.GLAccountNumber,
-                        AdjustmentYear = mpDistributionAdjustment.DonationDate.Year,
-                        AdjustmentMonth = mpDistributionAdjustment.DonationDate.Month
-                    };
-
-                    if (Math.Sign(mpDistributionAdjustment.Amount) == 1)
-                    {
-                        mpJournalEntry.CreditAmount = mpDistributionAdjustment.Amount;
-                    }
-                    else
-                    {
-                        mpJournalEntry.DebitAmount = Math.Abs(mpDistributionAdjustment.Amount);
-                    }
-
-                    journalEntries.Add(mpJournalEntry);
-                }
-                else
-                {
-                    bool isPositiveNumber = Math.Sign(mpDistributionAdjustment.Amount) == 1;
-
-                    if (isPositiveNumber)
-                    {
-                        matchingMpJournalEntry.CreditAmount += mpDistributionAdjustment.Amount;
-                    }
-                    else
-                    {
-                        matchingMpJournalEntry.DebitAmount += Math.Abs(mpDistributionAdjustment.Amount);
-                    }
-                }
-            }
+            List<MpJournalEntry> journalEntries = GroupAdjustmentsIntoJournalEntries(mpDistributionAdjustments, batchId);
+            journalEntries = _journalEntryService.RemoveWashEntries(journalEntries);
 
             // create journal entries
             var mpJournalEntries = _journalEntryRepository.CreateMpJournalEntries(journalEntries);
@@ -176,6 +135,30 @@ namespace Crossroads.Service.Finance.Services.Exports
             }
 
             return stringBuilder.ToString();
+        }
+
+        private List<MpJournalEntry> GroupAdjustmentsIntoJournalEntries(List<MpDistributionAdjustment> mpDistributionAdjustments, string batchId)
+        {
+            var journalEntries = new List<MpJournalEntry>();
+
+            foreach (var mpDistributionAdjustment in mpDistributionAdjustments)
+            {
+                var matchingMpJournalEntry = journalEntries.FirstOrDefault(r => r.GL_Account_Number == mpDistributionAdjustment.GLAccountNumber &&
+                                            r.AdjustmentYear == mpDistributionAdjustment.DonationDate.Year &&
+                                            r.AdjustmentMonth == mpDistributionAdjustment.DonationDate.Month);
+
+                if (matchingMpJournalEntry == null)
+                {
+                    MpJournalEntry newJournalEntry = _journalEntryService.CreateNewJournalEntry(batchId, mpDistributionAdjustment);
+                    journalEntries.Add(newJournalEntry);
+                }
+                else
+                {
+                    matchingMpJournalEntry = _journalEntryService.AdjustExistingJournalEntry(mpDistributionAdjustment, matchingMpJournalEntry);
+                }
+            }
+
+            return journalEntries;
         }
     }
 }

--- a/Crossroads.Service.Finance/Services/Exports/ExportService.cs
+++ b/Crossroads.Service.Finance/Services/Exports/ExportService.cs
@@ -154,7 +154,7 @@ namespace Crossroads.Service.Finance.Services.Exports
                 }
                 else
                 {
-                    matchingMpJournalEntry = _journalEntryService.AdjustExistingJournalEntry(mpDistributionAdjustment, matchingMpJournalEntry);
+                    _journalEntryService.AdjustExistingJournalEntry(mpDistributionAdjustment, matchingMpJournalEntry);
                 }
             }
 

--- a/Crossroads.Service.Finance/Services/JournalEntry/IJournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/IJournalEntryService.cs
@@ -5,7 +5,7 @@ namespace Crossroads.Service.Finance.Services.JournalEntry
 {
     public interface IJournalEntryService
     {
-        MpJournalEntry AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry);
+        void AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry);
         MpJournalEntry NetCreditsAndDebits(MpJournalEntry journalEntry);
         MpJournalEntry CreateNewJournalEntry(string batchId, MpDistributionAdjustment mpDistributionAdjustment);
         List<MpJournalEntry> RemoveWashEntries(List<MpJournalEntry> journalEntries);

--- a/Crossroads.Service.Finance/Services/JournalEntry/IJournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/IJournalEntryService.cs
@@ -1,0 +1,14 @@
+﻿using Exports.Models;
+using MinistryPlatform.Models;
+using System.Collections.Generic;
+
+namespace Crossroads.Service.Finance.Services.JournalEntry
+{
+    public interface IJournalEntryService
+    {
+        MpJournalEntry AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry);
+        MpJournalEntry NetCreditsAndDebits(MpJournalEntry journalEntry);
+        MpJournalEntry CreateNewJournalEntry(string batchId, MpDistributionAdjustment mpDistributionAdjustment);
+        List<MpJournalEntry> RemoveWashEntries(List<MpJournalEntry> journalEntries);
+    }
+}

--- a/Crossroads.Service.Finance/Services/JournalEntry/IJournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/IJournalEntryService.cs
@@ -1,5 +1,4 @@
-﻿using Exports.Models;
-using MinistryPlatform.Models;
+﻿using MinistryPlatform.Models;
 using System.Collections.Generic;
 
 namespace Crossroads.Service.Finance.Services.JournalEntry

--- a/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
@@ -1,9 +1,7 @@
-﻿using Exports.Models;
-using MinistryPlatform.Models;
+﻿using MinistryPlatform.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace Crossroads.Service.Finance.Services.JournalEntry
 {

--- a/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
@@ -9,7 +9,6 @@ namespace Crossroads.Service.Finance.Services.JournalEntry
     {
         public MpJournalEntry AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry)
         {
-
             if ( IsCredit(mpDistributionAdjustment) )
             {
                 journalEntry.CreditAmount += mpDistributionAdjustment.Amount;

--- a/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
@@ -7,7 +7,7 @@ namespace Crossroads.Service.Finance.Services.JournalEntry
 {
     public class JournalEntryService : IJournalEntryService
     {
-        public MpJournalEntry AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry)
+        public void AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry)
         {
             if ( IsCredit(mpDistributionAdjustment) )
             {
@@ -17,8 +17,6 @@ namespace Crossroads.Service.Finance.Services.JournalEntry
             {
                 journalEntry.DebitAmount += Math.Abs(mpDistributionAdjustment.Amount);
             }
-
-            return journalEntry;
         }
 
         public MpJournalEntry CreateNewJournalEntry(string batchId, MpDistributionAdjustment mpDistributionAdjustment)

--- a/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
+++ b/Crossroads.Service.Finance/Services/JournalEntry/JournalEntryService.cs
@@ -1,0 +1,89 @@
+﻿using Exports.Models;
+using MinistryPlatform.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Crossroads.Service.Finance.Services.JournalEntry
+{
+    public class JournalEntryService : IJournalEntryService
+    {
+        public MpJournalEntry AdjustExistingJournalEntry(MpDistributionAdjustment mpDistributionAdjustment, MpJournalEntry journalEntry)
+        {
+
+            if ( IsCredit(mpDistributionAdjustment) )
+            {
+                journalEntry.CreditAmount += mpDistributionAdjustment.Amount;
+            }
+            else
+            {
+                journalEntry.DebitAmount += Math.Abs(mpDistributionAdjustment.Amount);
+            }
+
+            return journalEntry;
+        }
+
+        public MpJournalEntry CreateNewJournalEntry(string batchId, MpDistributionAdjustment mpDistributionAdjustment)
+        {
+            var mpJournalEntry = new MpJournalEntry
+            {
+                BatchID = batchId,
+                CreatedDate = DateTime.Now,
+                ExportedDate = null,
+                Description = "test desc", // TODO: understand what goes here
+                GL_Account_Number = mpDistributionAdjustment.GLAccountNumber,
+                AdjustmentYear = mpDistributionAdjustment.DonationDate.Year,
+                AdjustmentMonth = mpDistributionAdjustment.DonationDate.Month
+            };
+
+            if ( IsCredit(mpDistributionAdjustment) )
+            {
+                mpJournalEntry.CreditAmount = mpDistributionAdjustment.Amount;
+            }
+            else
+            {
+                mpJournalEntry.DebitAmount = Math.Abs(mpDistributionAdjustment.Amount);
+            }
+
+            return mpJournalEntry;
+        }
+
+        public MpJournalEntry NetCreditsAndDebits(MpJournalEntry journalEntry)
+        {
+            if ( IsNetCredit(journalEntry) )
+            {
+                journalEntry.CreditAmount -= journalEntry.DebitAmount;
+                journalEntry.DebitAmount = 0;
+            }
+            else if ( IsNetDebit(journalEntry) )
+            {
+                journalEntry.DebitAmount -= journalEntry.CreditAmount;
+                journalEntry.CreditAmount = 0;
+            }
+
+            return journalEntry;
+        }
+
+        public List<MpJournalEntry> RemoveWashEntries(List<MpJournalEntry> journalEntries)
+        {
+            List<MpJournalEntry> nonRedundantAdjustments = journalEntries.Where(e => e.CreditAmount != e.DebitAmount).ToList<MpJournalEntry>();
+            return nonRedundantAdjustments;
+        }
+
+        private static bool IsNetDebit(MpJournalEntry journalEntry)
+        {
+            return journalEntry.DebitAmount > journalEntry.CreditAmount;
+        }
+
+        private static bool IsNetCredit(MpJournalEntry journalEntry)
+        {
+            return journalEntry.CreditAmount > journalEntry.DebitAmount;
+        }
+
+        private bool IsCredit(MpDistributionAdjustment mpDistributionAdjustment)
+        {
+            return Math.Sign(mpDistributionAdjustment.Amount) == 1;
+        }
+    }
+}

--- a/Crossroads.Service.Finance/Startup.cs
+++ b/Crossroads.Service.Finance/Startup.cs
@@ -26,6 +26,7 @@ using Exports.JournalEntries;
 using MinistryPlatform.Adjustments;
 using MinistryPlatform.JournalEntries;
 using Crossroads.Service.Finance.Services.JournalEntryBatch;
+using Crossroads.Service.Finance.Services.JournalEntry;
 
 namespace Crossroads.Service.Finance
 {
@@ -78,6 +79,7 @@ namespace Crossroads.Service.Finance
 
             // Service Layer
             services.AddSingleton<IBatchService, BatchService>();
+            services.AddSingleton<IJournalEntryService, JournalEntryService>();
             services.AddSingleton<IJournalEntryBatchService, JournalEntryBatchService>();
             services.AddSingleton<IContactService, ContactService>();
             services.AddSingleton<IDonationService, DonationService>();


### PR DESCRIPTION
- Any adjustments with an equal debit/credit to an account should be removed. E.g. $50 debit/$50 credit to same account is a wash and the "adjustment" should not be sent, as nothing is changed.
- If an adjusting entry has both a debit and a credit, it should be netted. E.g. $30 debit, $40 credit, should be a $0 debit and $10 credit - we only care about the net value